### PR TITLE
Fix font-size semicolon

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -20,7 +20,7 @@ const GlobalStyles = createGlobalStyle`
         font-family: 'Source Code Pro', monospace;
     }
     p, a, span{
-      font-size: clamp(15px, 80%, 24px);;
+      font-size: clamp(15px, 80%, 24px);
     }
 `;
 


### PR DESCRIPTION
## Summary
- fix an extra semicolon in `src/themes.js`

## Testing
- `npm test --silent -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab326d508324b300e12d224d121b